### PR TITLE
ExecuteQueryToFile - Fixed null parameters

### DIFF
--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.1] - 2024-02-12
+### Fixed
+- Fixed handling of null query parameters by changing the parameter value to DBNull.Value.
+
 ## [1.0.0] - 2024-02-07
 ### Changed
 - Initial implementation

--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.Tests/UnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.Tests/UnitTests.cs
@@ -241,4 +241,30 @@ public class UnitTests
 
         Assert.AreEqual(BitConverter.ToString(File.ReadAllBytes(Path.Combine(Path.GetDirectoryName(_destination), "Test_text.txt"))), output.TrimEnd(new char[] { '\r', '\n' }));
     }
+
+    [Test]
+    public async Task ExecuteQueryToFile_WithNULLParameter()
+    {
+        var query = new Input
+        {
+            Query = $"SELECT * FROM {_tableName} WHERE TestNull = @param",
+            QueryParameters = new Definitions.SqlParameter[]
+            {
+                new Definitions.SqlParameter
+                {
+                    Name = "@param",
+                    Value = null,
+                    SqlDataType = SqlDataTypes.VarChar,
+                },
+            },
+            ConnectionString = _connString,
+            OutputFilePath = _destination,
+        };
+
+        await MicrosoftSQL.ExecuteQueryToFile(query, _options, default);
+
+        var output = File.ReadAllText(_destination);
+
+        Assert.IsNotNull(output);
+    }
 }

--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.Tests/lib/Helper.cs
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.Tests/lib/Helper.cs
@@ -17,7 +17,7 @@ internal static class Helper
         using var connection = new SqlConnection(connString);
         connection.Open();
         var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{tableName}') BEGIN CREATE TABLE {tableName} ( Id int, LastName varchar(255), FirstName varchar(255), Salary decimal(6,2), Image Image, TestText VarBinary(MAX)); END";
+        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{tableName}') BEGIN CREATE TABLE {tableName} ( Id int, LastName varchar(255), FirstName varchar(255), Salary decimal(6,2), Image Image, TestText VarBinary(MAX), TestNull Varchar(255)); END";
         createTable.ExecuteNonQuery();
         connection.Close();
     }

--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Definitions/SqlParameter.cs
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Definitions/SqlParameter.cs
@@ -16,6 +16,7 @@ public class SqlParameter
 
     /// <summary>
     /// The value of the parameter.
+    /// If value is null, it is changed to DBNull in the Task.
     /// </summary>
     /// <example>FirstName</example>
     public object Value { get; set; }

--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.cs
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.cs
@@ -38,15 +38,15 @@ public static class MicrosoftSQL
             {
                 foreach (var parameter in input.QueryParameters)
                 {
+                    if (parameter.Value is null)
+                        parameter.Value = DBNull.Value;
+
                     if (parameter.SqlDataType is SqlDataTypes.Auto)
                     {
                         command.Parameters.AddWithValue(parameterName: parameter.Name, value: parameter.Value);
                     }
                     else
                     {
-                        if (parameter.Value is null)
-                            parameter.Value = DBNull.Value;
-
                         var sqlDbType = (SqlDbType)Enum.Parse(typeof(SqlDbType), parameter.SqlDataType.ToString());
                         var commandParameter = command.Parameters.Add(parameter.Name, sqlDbType);
                         commandParameter.Value = parameter.Value;

--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.cs
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.cs
@@ -44,6 +44,9 @@ public static class MicrosoftSQL
                     }
                     else
                     {
+                        if (parameter.Value is null)
+                            parameter.Value = DBNull.Value;
+
                         var sqlDbType = (SqlDbType)Enum.Parse(typeof(SqlDbType), parameter.SqlDataType.ToString());
                         var commandParameter = command.Parameters.Add(parameter.Name, sqlDbType);
                         commandParameter.Value = parameter.Value;

--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.csproj
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	  <TargetFramework>net6.0</TargetFramework>
 	  <LangVersion>Latest</LangVersion>
-	  <Version>1.0.0</Version>
+	  <Version>1.0.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/GlobalSuppressions.cs
+++ b/Frends.MicrosoftSQL.ExecuteQueryToFile/Frends.MicrosoftSQL.ExecuteQueryToFile/GlobalSuppressions.cs
@@ -9,4 +9,4 @@
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File should have header", Justification = "Following Frends guidelines")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:Enumeration items should be documented", Justification = "Following Frends guidelines", Scope = "namespaceanddescendants", Target = "~N:Frends.MicrosoftSQL.ExecuteQueryToFile.Enums")]
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1200:Using directives should be placed correctly", Justification = "Following Frends guidelines")]
-[assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces should not be omitted", Justification = "Following Frends guidelines", Scope = "namespaceanddescendants", Target = "~N:Frends.MicrosoftSQL.ExecuteQueryToFile.Definitions")]
+[assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces should not be omitted", Justification = "Following Frends guidelines", Scope = "namespaceanddescendants", Target = "~N:Frends.MicrosoftSQL.ExecuteQueryToFile")]


### PR DESCRIPTION
#38 

## [1.0.1] - 2024-02-12
### Fixed
- Fixed handling of null query parameters by changing the parameter value to DBNull.Value.