### PR TITLE
ExecuteQuery - Removed SqlConnection.ClearAllPools() to make the Task more efficient

### DIFF
--- a/Frends.MicrosoftSQL.ExecuteQuery/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.1] - 2024-03-01
+### Changed
+- Removed finally block from the Task so that the SQLConnection pool is not touched after every call to the ExecuteQuery method.
+### Updated
+- Newtonsoft.Json to version 13.0.3
+- System.Data.SqlClient to version 4.8.6
+
 ## [1.2.0] - 2023-11-30
 ### Changed
 - [Breaking] QueryParameter.Value type to object so that binary data can be used.

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/AutoUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/AutoUnitTests.cs
@@ -1,50 +1,13 @@
 using Frends.MicrosoftSQL.ExecuteQuery.Definitions;
+using Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
-using System.Data.SqlClient;
 
 namespace Frends.MicrosoftSQL.ExecuteQuery.Tests;
 
 [TestClass]
-public class AutoUnitTests
+public class AutoUnitTests : ExecuteQueryTestBase
 {
-    /*
-        docker-compose up -d
-
-        How to use via terminal:
-        docker exec -it sql1 "bash"
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Salakala123!"
-        SELECT * FROM TestTable
-        GO
-   */
-
-    private static readonly string _connString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!";
-    private static readonly string _tableName = "TestTable";
-
-    [TestInitialize]
-    public void Init()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN CREATE TABLE {_tableName} ( Id int, LastName varchar(255), FirstName varchar(255) ); END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
-    [TestCleanup]
-    public void CleanUp()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN DROP TABLE IF EXISTS {_tableName}; END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
     [TestMethod]
     public async Task TestExecuteQuery_Auto()
     {
@@ -113,7 +76,7 @@ public class AutoUnitTests
             Assert.AreEqual(3, insert.RecordsAffected);
             Assert.IsNull(insert.ErrorMessage);
             Assert.AreEqual(3, (int)insert.Data["AffectedRows"]);
-            Assert.AreEqual(3, GetRowCount()); // Make sure rows inserted before moving on.
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // Make sure rows inserted before moving on.
 
             // Select all
             var select = await MicrosoftSQL.ExecuteQuery(inputSelect, options, default);
@@ -127,7 +90,7 @@ public class AutoUnitTests
             Assert.AreEqual("Forst", (string)select.Data[1]["FirstName"]);
             Assert.AreEqual("Hiiri", (string)select.Data[2]["LastName"]);
             Assert.AreEqual("Mikki", (string)select.Data[2]["FirstName"]);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
 
             // Select single
             var selectSingle = await MicrosoftSQL.ExecuteQuery(inputSelectSingle, options, default);
@@ -137,14 +100,14 @@ public class AutoUnitTests
             Assert.AreEqual(typeof(JArray), selectSingle.Data.GetType());
             Assert.AreEqual("Suku", (string)selectSingle.Data[0]["LastName"]);
             Assert.AreEqual("Etu", (string)selectSingle.Data[0]["FirstName"]);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
 
             // Update
             var update = await MicrosoftSQL.ExecuteQuery(inputUpdate, options, default);
             Assert.IsTrue(update.Success);
             Assert.AreEqual(1, update.RecordsAffected);
             Assert.IsNull(update.ErrorMessage);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
             var checkUpdateResult = await MicrosoftSQL.ExecuteQuery(inputSelect, options, default);
             Assert.AreEqual("Suku", (string)checkUpdateResult.Data[0]["LastName"]);
             Assert.AreEqual("Etu", (string)checkUpdateResult.Data[0]["FirstName"]);
@@ -152,14 +115,14 @@ public class AutoUnitTests
             Assert.AreEqual("Forst", (string)checkUpdateResult.Data[1]["FirstName"]);
             Assert.AreEqual("Hiiri", (string)checkUpdateResult.Data[2]["LastName"]);
             Assert.AreEqual("Mikki", (string)checkUpdateResult.Data[2]["FirstName"]);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
 
             // Delete
             var delete = await MicrosoftSQL.ExecuteQuery(inputDelete, options, default);
             Assert.IsTrue(delete.Success);
             Assert.AreEqual(1, delete.RecordsAffected);
             Assert.IsNull(delete.ErrorMessage);
-            Assert.AreEqual(2, GetRowCount()); // double check
+            Assert.AreEqual(2, Helper.GetRowCount(_connString, _tableName)); // double check
             var checkDeleteResult = await MicrosoftSQL.ExecuteQuery(inputSelect, options, default);
             Assert.AreEqual("Suku", (string)checkDeleteResult.Data[0]["LastName"]);
             Assert.AreEqual("Etu", (string)checkDeleteResult.Data[0]["FirstName"]);
@@ -168,17 +131,5 @@ public class AutoUnitTests
 
             CleanUp();
         }
-    }
-
-    private static int GetRowCount()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var getRows = connection.CreateCommand();
-        getRows.CommandText = $"SELECT COUNT(*) FROM {_tableName}";
-        var count = (int)getRows.ExecuteScalar();
-        connection.Close();
-        connection.Dispose();
-        return count;
     }
 }

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ExceptionUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ExceptionUnitTests.cs
@@ -7,20 +7,29 @@ namespace Frends.MicrosoftSQL.ExecuteQuery.Tests;
 [TestClass]
 public class ExceptionUnitTests : ExecuteQueryTestBase
 {
-    [TestMethod]
-    public async Task TestExecuteQuery_Invalid_Creds_ThrowError()
+    private Input input = new();
+    private Options options = new();
+
+    [TestInitialize]
+    public void SetUp()
     {
-        var input = new Input()
+        input = new Input()
         {
-            ConnectionString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=WrongPassWord",
+            ConnectionString = _connString,
         };
 
-        var options = new Options()
+        options = new Options()
         {
             SqlTransactionIsolationLevel = SqlTransactionIsolationLevel.ReadCommitted,
             CommandTimeoutSeconds = 2,
             ThrowErrorOnFailure = true
         };
+    }
+
+    [TestMethod]
+    public async Task TestExecuteQuery_Invalid_Creds_ThrowError()
+    {
+        input.ConnectionString = Helper.GetInvalidConnectionString();
 
         var ex = await Assert.ThrowsExceptionAsync<Exception>(() => MicrosoftSQL.ExecuteQuery(input, options, default));
         Assert.IsTrue(ex.Message.Contains("Login failed for user 'SA'."));
@@ -29,17 +38,8 @@ public class ExceptionUnitTests : ExecuteQueryTestBase
     [TestMethod]
     public async Task TestExecuteQuery_Invalid_Creds_ReturnErrorMessage()
     {
-        var input = new Input()
-        {
-            ConnectionString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=WrongPassWord",
-        };
-
-        var options = new Options()
-        {
-            SqlTransactionIsolationLevel = SqlTransactionIsolationLevel.ReadCommitted,
-            CommandTimeoutSeconds = 2,
-            ThrowErrorOnFailure = false
-        };
+        options.ThrowErrorOnFailure = false;
+        input.ConnectionString = Helper.GetInvalidConnectionString();
 
         var result = await MicrosoftSQL.ExecuteQuery(input, options, default);
         Assert.IsFalse(result.Success);
@@ -50,19 +50,8 @@ public class ExceptionUnitTests : ExecuteQueryTestBase
     [TestMethod]
     public void TestExecuteQuery_ExceptionIsThrownWhenQueryFails()
     {
-        var input = new Input()
-        {
-            Query = $"INSERT INTO {_tableName} VALUES (1, Unit, Tests, 456)",
-            ExecuteType = ExecuteTypes.NonQuery,
-            ConnectionString = _connString,
-        };
-
-        var options = new Options()
-        {
-            SqlTransactionIsolationLevel = SqlTransactionIsolationLevel.ReadCommitted,
-            CommandTimeoutSeconds = 2,
-            ThrowErrorOnFailure = true
-        };
+        input.Query = $"INSERT INTO {_tableName} VALUES (1, Unit, Tests, 456)";
+        input.ExecuteType = ExecuteTypes.NonQuery;
 
         var ex = Assert.ThrowsExceptionAsync<Exception>(async () => await MicrosoftSQL.ExecuteQuery(input, options, default));
         Assert.IsTrue(ex.Result.Message.Contains("System.Data.SqlClient.SqlException (0x80131904): Invalid column name 'Unit'."));
@@ -71,19 +60,10 @@ public class ExceptionUnitTests : ExecuteQueryTestBase
     [TestMethod]
     public async Task TestExecuteQuery_ErrorMessageWhenQueryFails()
     {
-        var input = new Input()
-        {
-            Query = $"INSERT INTO {_tableName} VALUES (1, Unit, Tests, 456)",
-            ExecuteType = ExecuteTypes.NonQuery,
-            ConnectionString = _connString,
-        };
+        input.Query = $"INSERT INTO {_tableName} VALUES (1, Unit, Tests, 456)";
+        input.ExecuteType = ExecuteTypes.NonQuery;
 
-        var options = new Options()
-        {
-            SqlTransactionIsolationLevel = SqlTransactionIsolationLevel.ReadCommitted,
-            CommandTimeoutSeconds = 2,
-            ThrowErrorOnFailure = false
-        };
+        options.ThrowErrorOnFailure = false;
 
         var result = await MicrosoftSQL.ExecuteQuery(input, options, default);
         Assert.IsFalse(result.Success);

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ExceptionUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ExceptionUnitTests.cs
@@ -1,49 +1,12 @@
 using Frends.MicrosoftSQL.ExecuteQuery.Definitions;
+using Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Data.SqlClient;
 
 namespace Frends.MicrosoftSQL.ExecuteQuery.Tests;
 
 [TestClass]
-public class ExceptionUnitTests
+public class ExceptionUnitTests : ExecuteQueryTestBase
 {
-    /*
-        docker-compose up
-
-        How to use via terminal:
-        docker exec -it sql1 "bash"
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Salakala123!"
-        SELECT * FROM TestTable
-        GO
-   */
-
-    private static readonly string _connString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!";
-    private static readonly string _tableName = "TestTable";
-
-    [TestInitialize]
-    public void Init()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN CREATE TABLE {_tableName} ( Id int, LastName varchar(255), FirstName varchar(255) ); END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
-    [TestCleanup]
-    public void CleanUp()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN DROP TABLE IF EXISTS {_tableName}; END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
     [TestMethod]
     public async Task TestExecuteQuery_Invalid_Creds_ThrowError()
     {

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Frends.MicrosoftSQL.ExecuteQuery.Tests.csproj
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Frends.MicrosoftSQL.ExecuteQuery.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-	<PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+	<PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/ExecuteQueryTestBase.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/ExecuteQueryTestBase.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
 

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/ExecuteQueryTestBase.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/ExecuteQueryTestBase.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
+
+public class ExecuteQueryTestBase
+{
+    internal static readonly string _connString = Helper.CreateConnectionString();
+    internal static readonly string _tableName = "TestTable";
+
+    [TestInitialize]
+    public void Init()
+    {
+        using var connection = new SqlConnection(_connString);
+        connection.Open();
+        var createTable = connection.CreateCommand();
+        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN CREATE TABLE {_tableName} ( Id int, LastName varchar(255), FirstName varchar(255) ); END";
+        createTable.ExecuteNonQuery();
+        connection.Close();
+        connection.Dispose();
+    }
+
+    [TestCleanup]
+    public void CleanUp()
+    {
+        using var connection = new SqlConnection(_connString);
+        connection.Open();
+        var createTable = connection.CreateCommand();
+        createTable.CommandText = $@"IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN DROP TABLE IF EXISTS {_tableName}; END";
+        createTable.ExecuteNonQuery();
+        connection.Close();
+        connection.Dispose();
+    }
+}

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
@@ -6,7 +6,7 @@ internal class Helper
 {
     internal static string CreateConnectionString()
     {
-        return "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!";
+        return "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!;Encrypt=true;TrustServerCertificate=True;";
     }
 
     internal static int GetRowCount(string connString, string table)

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
@@ -1,0 +1,23 @@
+﻿using System.Data.SqlClient;
+
+namespace Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
+
+internal class Helper
+{
+    internal static string CreateConnectionString()
+    {
+        return "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!";
+    }
+
+    internal static int GetRowCount(string connString, string table)
+    {
+        using var connection = new SqlConnection(connString);
+        connection.Open();
+        var getRows = connection.CreateCommand();
+        getRows.CommandText = $"SELECT COUNT(*) FROM {table}";
+        var count = (int)getRows.ExecuteScalar();
+        connection.Close();
+        connection.Dispose();
+        return count;
+    }
+}

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
@@ -6,7 +6,8 @@ internal class Helper
 {
     internal static string CreateConnectionString()
     {
-        return "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!;Encrypt=true;TrustServerCertificate=True;";
+        var pw = "Salakala123!";
+        return $"Server=127.0.0.1,1433;Database=Master;User Id=SA;Password={pw};Encrypt=true;TrustServerCertificate=True;";
     }
 
     internal static int GetRowCount(string connString, string table)

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/Helper.cs
@@ -4,10 +4,21 @@ namespace Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
 
 internal class Helper
 {
+    /// <summary>
+    /// Test credentials for docker server.
+    /// </summary>
+    private static readonly string _dockerAddress = "127.0.0.1,1433";
+    private static readonly string _dockerUsername = "SA";
+    private static readonly string _dockerPassword = "Salakala123!";
+
     internal static string CreateConnectionString()
     {
-        var pw = "Salakala123!";
-        return $"Server=127.0.0.1,1433;Database=Master;User Id=SA;Password={pw};Encrypt=true;TrustServerCertificate=True;";
+        return $"Server={_dockerAddress};Database=Master;User Id={_dockerUsername};Password={_dockerPassword};Encrypt=true;TrustServerCertificate=True;";
+    }
+
+    internal static string GetInvalidConnectionString()
+    {
+        return $"Server=127.0.0.1,1433;Database=Master;User Id={_dockerUsername};Password={Guid.NewGuid()};Encrypt=true;TrustServerCertificate=True;";
     }
 
     internal static int GetRowCount(string connString, string table)

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ManualTesting.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ManualTesting.cs
@@ -1,51 +1,12 @@
 using Frends.MicrosoftSQL.ExecuteQuery.Definitions;
+using Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Data.SqlClient;
 
 namespace Frends.MicrosoftSQL.ExecuteQuery.Tests;
 
 [TestClass]
-public class ManualTesting
+public class ManualTesting : ExecuteQueryTestBase
 {
-    /*
-        These tests requires code editing so they must be skipped in workflow.
-
-        docker-compose up
-
-        How to use via terminal:
-        docker exec -it sql1 "bash"
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Salakala123!"
-        SELECT * FROM TestTable
-        GO
-   */
-
-    private static readonly string _connString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!";
-    private static readonly string _tableName = "TestTable";
-
-    [TestInitialize]
-    public void Init()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN CREATE TABLE {_tableName} ( Id int, LastName varchar(255), FirstName varchar(255) ); END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
-    [TestCleanup]
-    public void CleanUp()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN DROP TABLE IF EXISTS {_tableName}; END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
     // Add following line to ExecuteQuery.cs: 'throw new Exception();' under 'dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);' (currently line 124)
     [Ignore("To run this test, comment this line after exception has been added to ExecuteQuery.cs.")]
     [TestMethod]
@@ -71,7 +32,7 @@ public class ManualTesting
         Assert.IsFalse(insert.Success);
         Assert.AreEqual(0, insert.RecordsAffected);
         Assert.IsTrue(insert.ErrorMessage.Contains("(If required) transaction rollback completed without exception."));
-        Assert.AreEqual(0, GetRowCount());
+        Assert.AreEqual(0, Helper.GetRowCount(_connString, _tableName));
     }
 
     // Add following line to ExecuteQuery.cs: 'throw new Exception();' under 'dataReader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);' (currently line 124)
@@ -97,18 +58,5 @@ public class ManualTesting
         // Insert rows
         var insert = await Assert.ThrowsExceptionAsync<Exception>(async () => await MicrosoftSQL.ExecuteQuery(inputInsert, options, default));
         Assert.IsTrue(insert.Message.Contains("(If required) transaction rollback completed without exception."));
-    }
-
-    // Simple select statement for result double checks.
-    private static int GetRowCount()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var getRows = connection.CreateCommand();
-        getRows.CommandText = $"SELECT COUNT(*) FROM {_tableName}";
-        var count = (int)getRows.ExecuteScalar();
-        connection.Close();
-        connection.Dispose();
-        return count;
     }
 }

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/NonQueryUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/NonQueryUnitTests.cs
@@ -1,49 +1,12 @@
 using Frends.MicrosoftSQL.ExecuteQuery.Definitions;
+using Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Data.SqlClient;
 
 namespace Frends.MicrosoftSQL.ExecuteQuery.Tests;
 
 [TestClass]
-public class NonQueryUnitTests
+public class NonQueryUnitTests : ExecuteQueryTestBase
 {
-    /*
-        docker-compose up
-
-        How to use via terminal:
-        docker exec -it sql1 "bash"
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Salakala123!"
-        SELECT * FROM TestTable
-        GO
-   */
-
-    private static readonly string _connString = "Server=127.0.0.1,1433;Database=Master;User Id=SA;Password=Salakala123!";
-    private static readonly string _tableName = "TestTable";
-
-    [TestInitialize]
-    public void Init()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN CREATE TABLE {_tableName} ( Id int, LastName varchar(255), FirstName varchar(255) ); END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
-    [TestCleanup]
-    public void CleanUp()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN DROP TABLE IF EXISTS {_tableName}; END";
-        createTable.ExecuteNonQuery();
-        connection.Close();
-        connection.Dispose();
-    }
-
     [TestMethod]
     public async Task TestExecuteQuery_NonQuery()
     {
@@ -119,7 +82,7 @@ public class NonQueryUnitTests
             Assert.AreEqual(3, insert.RecordsAffected);
             Assert.IsNull(insert.ErrorMessage);
             Assert.AreEqual(3, (int)insert.Data["AffectedRows"]);
-            Assert.AreEqual(3, GetRowCount()); // Make sure rows inserted before moving on.
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // Make sure rows inserted before moving on.
 
             // Select all
             var select = await MicrosoftSQL.ExecuteQuery(inputSelect, options, default);
@@ -127,7 +90,7 @@ public class NonQueryUnitTests
             Assert.AreEqual(-1, select.RecordsAffected);
             Assert.IsNull(select.ErrorMessage);
             Assert.AreEqual(-1, (int)select.Data["AffectedRows"]);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
 
             // Select single
             var selectSingle = await MicrosoftSQL.ExecuteQuery(inputSelectSingle, options, default);
@@ -135,14 +98,14 @@ public class NonQueryUnitTests
             Assert.AreEqual(-1, selectSingle.RecordsAffected);
             Assert.IsNull(selectSingle.ErrorMessage);
             Assert.AreEqual(-1, (int)select.Data["AffectedRows"]);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
 
             // Update
             var update = await MicrosoftSQL.ExecuteQuery(inputUpdate, options, default);
             Assert.IsTrue(update.Success);
             Assert.AreEqual(1, update.RecordsAffected);
             Assert.IsNull(update.ErrorMessage);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
             var checkUpdateResult = await MicrosoftSQL.ExecuteQuery(inputSelectAfterExecution, options, default);
             Assert.AreEqual("Suku", (string)checkUpdateResult.Data[0]["LastName"]);
             Assert.AreEqual("Etu", (string)checkUpdateResult.Data[0]["FirstName"]);
@@ -150,14 +113,14 @@ public class NonQueryUnitTests
             Assert.AreEqual("Forst", (string)checkUpdateResult.Data[1]["FirstName"]);
             Assert.AreEqual("Hiiri", (string)checkUpdateResult.Data[2]["LastName"]);
             Assert.AreEqual("Mikki", (string)checkUpdateResult.Data[2]["FirstName"]);
-            Assert.AreEqual(3, GetRowCount()); // double check
+            Assert.AreEqual(3, Helper.GetRowCount(_connString, _tableName)); // double check
 
             // Delete
             var delete = await MicrosoftSQL.ExecuteQuery(inputDelete, options, default);
             Assert.IsTrue(delete.Success);
             Assert.AreEqual(1, delete.RecordsAffected);
             Assert.IsNull(delete.ErrorMessage);
-            Assert.AreEqual(2, GetRowCount()); // double check
+            Assert.AreEqual(2, Helper.GetRowCount(_connString, _tableName)); // double check
             var checkDeleteResult = await MicrosoftSQL.ExecuteQuery(inputSelectAfterExecution, options, default);
             Assert.AreEqual("Suku", (string)checkDeleteResult.Data[0]["LastName"]);
             Assert.AreEqual("Etu", (string)checkDeleteResult.Data[0]["FirstName"]);
@@ -166,17 +129,5 @@ public class NonQueryUnitTests
 
             CleanUp();
         }
-    }
-
-    private static int GetRowCount()
-    {
-        using var connection = new SqlConnection(_connString);
-        connection.Open();
-        var getRows = connection.CreateCommand();
-        getRows.CommandText = $"SELECT COUNT(*) FROM {_tableName}";
-        var count = (int)getRows.ExecuteScalar();
-        connection.Close();
-        connection.Dispose();
-        return count;
     }
 }

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ScalarUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ScalarUnitTests.cs
@@ -1,7 +1,6 @@
 using Frends.MicrosoftSQL.ExecuteQuery.Definitions;
 using Frends.MicrosoftSQL.ExecuteQuery.Tests.Lib;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Data.SqlClient;
 
 namespace Frends.MicrosoftSQL.ExecuteQuery.Tests;
 

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
@@ -79,7 +79,7 @@ public class MicrosoftSQL
         Result result;
         object dataObject;
         SqlDataReader dataReader = null;
-        var table = new DataTable();
+        using var table = new DataTable();
 
         try
         {

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
@@ -72,10 +72,6 @@ public class MicrosoftSQL
 
             return new Result(false, 0, eMsg, null);
         }
-        finally
-        {
-            SqlConnection.ClearAllPools();
-        }
     }
 
     private static async Task<Result> ExecuteHandler(Input input, Options options, SqlCommand command, CancellationToken cancellationToken)

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.csproj
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.2.0</Version>
+	<Version>1.2.1</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -22,7 +22,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#41 

## [1.2.1] - 2024-03-01
### Changed
- Removed finally block from the Task so that the SQLConnection pool is not touched after every call to the ExecuteQuery method.
### Updated
- Newtonsoft.Json to version 13.0.3
- System.Data.SqlClient to version 4.8.6