### PR TITLE
Newtonsoft.Json updates

### DIFF
--- a/Frends.MicrosoftSQL.BatchOperation/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.BatchOperation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0] - 2024-08-26
+### Changed
+- Updated Newtonsoft.Json to the latest version 13.0.3.
+
 ## [2.0.0] - 2024-08-05
 ### Changed
 - [Breaking] The task now uses Microsoft.Data.SqlClient instead of System.Data.SqlClient.

--- a/Frends.MicrosoftSQL.BatchOperation/Frends.MicrosoftSQL.BatchOperation/Frends.MicrosoftSQL.BatchOperation.csproj
+++ b/Frends.MicrosoftSQL.BatchOperation/Frends.MicrosoftSQL.BatchOperation/Frends.MicrosoftSQL.BatchOperation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.0.0</Version>
+	<Version>2.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -24,7 +24,7 @@
   <ItemGroup>
   	<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/Frends.MicrosoftSQL.BulkInsert/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.BulkInsert/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0] - 2024-08-26
+### Changed
+- Updated Newtonsoft.Json to the latest version 13.0.3.
+
 ## [2.0.0] - 2024-08-05
 ### Changed
 - [Breaking] The task now uses Microsoft.Data.SqlClient instead of System.Data.SqlClient.

--- a/Frends.MicrosoftSQL.BulkInsert/Frends.MicrosoftSQL.BulkInsert/Frends.MicrosoftSQL.BulkInsert.csproj
+++ b/Frends.MicrosoftSQL.BulkInsert/Frends.MicrosoftSQL.BulkInsert/Frends.MicrosoftSQL.BulkInsert.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.0.0</Version>
+	<Version>2.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -23,6 +23,6 @@
 	
   <ItemGroup>
   	<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/Frends.MicrosoftSQL.ExecuteProcedure/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.ExecuteProcedure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0] - 2024-08-26
+### Changed
+- Updated Newtonsoft.Json to the latest version 13.0.3.
+
 ## [2.0.0] - 2024-08-05
 ### Changed
 - [Breaking] The task now uses Microsoft.Data.SqlClient instead of System.Data.SqlClient.

--- a/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.csproj
+++ b/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.0.0</Version>
+	<Version>2.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -23,6 +23,6 @@
 	
   <ItemGroup>
   	<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #54 . Dependabot alerts have been accessed by updating Newtonsoft.Json to the latest version 13.0.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the Newtonsoft.Json library to version 13.0.3 across multiple modules, enhancing JSON handling capabilities.
  - Incremented version numbers to 2.1.0 for `Frends.MicrosoftSQL.BatchOperation`, `Frends.MicrosoftSQL.BulkInsert`, and `Frends.MicrosoftSQL.ExecuteProcedure`, indicating a new release.

- **Breaking Changes**
  - Transitioned from `System.Data.SqlClient` to `Microsoft.Data.SqlClient` in previous versions, which may affect existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->