### PR TITLE
MicrosoftSQL.ExecuteQuery - Added handling of SqlGeoraphy objects

### DIFF
--- a/Frends.MicrosoftSQL.ExecuteQuery/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.ExecuteQuery/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [2.2.0] - 2024-11-26
 ### Added
-- Added method to form JToken from the SqlDataReader so that SqlGeography typed objects can be handled.
-- Fixed how Scalar handles the data so that SqlGeography typed objects can be handled.
+- Added method to form JToken from the SqlDataReader so that SqlGeography and SqlGeometry typed objects can be handled.
+- Fixed how Scalar handles the data so that SqlGeography and SqlGeometry typed objects can be handled.
 - Added Microsoft.SqlServer.Types version 160.1000.6 as dependency.
 
 ## [2.1.0] - 2024-09-10

--- a/Frends.MicrosoftSQL.ExecuteQuery/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.0] - 2024-11-26
+### Added
+- Added method to form JToken from the SqlDataReader so that SqlGeography typed objects can be handled.
+- Fixed how Scalar handles the data so that SqlGeography typed objects can be handled.
+- Added Microsoft.SqlServer.Types version 160.1000.6 as dependency.
+
 ## [2.1.0] - 2024-09-10
 ### Fixed
 - Fixed how null values are handled by setting them as DBNull.Value.

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/ExecuteQueryTestBase.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/Lib/ExecuteQueryTestBase.cs
@@ -14,7 +14,7 @@ public class ExecuteQueryTestBase
         using var connection = new SqlConnection(_connString);
         connection.Open();
         var createTable = connection.CreateCommand();
-        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN CREATE TABLE {_tableName} ( Id int, LastName varchar(255), FirstName varchar(255) ); END";
+        createTable.CommandText = $@"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{_tableName}') BEGIN CREATE TABLE {_tableName} ( Id int, LastName varchar(255), FirstName varchar(255)); END";
         createTable.ExecuteNonQuery();
         connection.Close();
         connection.Dispose();

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ScalarUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.Tests/ScalarUnitTests.cs
@@ -130,4 +130,50 @@ public class ScalarUnitTests : ExecuteQueryTestBase
             CleanUp();
         }
     }
+
+    [TestMethod]
+    public async Task TestWithGeographyData_Scalar()
+    {
+        var table = "geographytest";
+
+        var options = new Options()
+        {
+            SqlTransactionIsolationLevel = SqlTransactionIsolationLevel.None,
+            CommandTimeoutSeconds = 2,
+            ThrowErrorOnFailure = true
+        };
+
+        var input = new Input
+        {
+            ConnectionString = _connString,
+            Query = $"IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{table}') BEGIN CREATE TABLE {table} ( Id int IDENTITY(1, 1), GeogCol1 geography, GeogCol2 AS GeogCol1.STAsText()); END",
+            ExecuteType = ExecuteTypes.Auto,
+            Parameters = null
+        };
+
+        var create = await MicrosoftSQL.ExecuteQuery(input, options, default);
+        Assert.IsTrue(create.Success, "Create table");
+
+        input.Query = $"INSERT INTO {table} (GeogCol1) VALUES (geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326));";
+
+        var insert1 = await MicrosoftSQL.ExecuteQuery(input, options, default);
+        Assert.IsTrue(insert1.Success, "First insert");
+
+        input.Query = $"INSERT INTO {table} (GeogCol1) VALUES(geography::STGeomFromText('POLYGON((-122.358 47.653 , -122.348 47.649, -122.348 47.658, -122.358 47.658, -122.358 47.653))', 4326));";
+
+        var insert2 = await MicrosoftSQL.ExecuteQuery(input, options, default);
+        Assert.IsTrue(insert2.Success, "Second insert");
+
+        input.Query = $"SELECT GeogCol1 From {table}";
+        input.ExecuteType = ExecuteTypes.Scalar;
+
+        var select = await MicrosoftSQL.ExecuteQuery(input, options, default);
+        Assert.IsTrue(select.Success, "Select");
+
+        input.Query = $"DROP TABLE {table}";
+        input.ExecuteType = ExecuteTypes.Auto;
+
+        var drop = await MicrosoftSQL.ExecuteQuery(input, options, default);
+        Assert.IsTrue(drop.Success, "Drop");
+    }
 }

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
@@ -118,7 +118,7 @@ public class MicrosoftSQL
                     dataObject = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
                     // JToken.FromObject() method can't handle SqlGeography typed objects so we convert it into string.
-                    if (dataObject != null && dataObject.GetType() == typeof(SqlGeography))
+                    if (dataObject != null && (dataObject.GetType() == typeof(SqlGeography) || dataObject.GetType() == typeof(SqlGeometry)))
                         dataObject = dataObject.ToString();
 
                     result = new Result(true, 1, null, JToken.FromObject(new { Value = dataObject }));
@@ -187,6 +187,8 @@ public class MicrosoftSQL
                         value = null;
                     else if (fieldValue is SqlGeography geography)
                         value = geography.ToString();
+                    else if (fieldValue is SqlGeometry geometry)
+                        value = geometry.ToString();
                     else
                         value = fieldValue;
 

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
@@ -93,7 +93,6 @@ public class MicrosoftSQL
         Result result;
         object dataObject;
         SqlDataReader dataReader = null;
-        using var table = new DataTable();
 
         try
         {
@@ -168,6 +167,11 @@ public class MicrosoftSQL
                 else
                     return new Result(false, 0, $"ExecuteHandler exception: (If required) transaction rollback completed without exception. {ex}.", null);
             }
+        }
+        finally
+        {
+            if (dataReader != null && !dataReader.IsClosed)
+                await dataReader.CloseAsync();
         }
     }
 

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/ExecuteQuery.cs
@@ -181,13 +181,14 @@ public class MicrosoftSQL
                 var row = new JObject();
                 for (var i = 0; i < reader.FieldCount; i++)
                 {
-                    dynamic value;
-                    if (reader.GetValue(i).GetType() == typeof(DBNull))
+                    object fieldValue = reader.GetValue(i);
+                    object value;
+                    if (fieldValue == DBNull.Value)
                         value = null;
-                    else if (reader.GetValue(i).GetType() == typeof(SqlGeography))
-                        value = reader.GetValue(i).ToString();
+                    else if (fieldValue is SqlGeography geography)
+                        value = geography.ToString();
                     else
-                        value = reader.GetValue(i);
+                        value = fieldValue;
 
                     row.Add(new JProperty(reader.GetName(i), value));
                 }

--- a/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.csproj
+++ b/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery/Frends.MicrosoftSQL.ExecuteQuery.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.1.0</Version>
+	<Version>2.2.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -24,5 +24,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	<PackageReference Include="Microsoft.SqlServer.Types" Version="160.1000.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#59 

## [2.2.0] - 2024-11-26
### Added
- Added method to form JToken from the SqlDataReader so that SqlGeography typed objects can be handled.
- Fixed how Scalar handles the data so that SqlGeography typed objects can be handled.
- Added Microsoft.SqlServer.Types version 160.1000.6 as dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for Frends.MicrosoftSQL.ExecuteQuery Version 2.2.0

- **New Features**
  - Introduced a method to create a `JToken` from `SqlDataReader`, enhancing data handling for `SqlGeography` and `SqlGeometry` types.
  - Improved handling of `SqlGeography` in scalar queries.
  - Added new test methods for validating geography data handling in SQL operations.

- **Bug Fixes**
  - Enhanced error handling for transaction rollbacks, providing clearer exception messages.

- **Chores**
  - Updated project version to 2.2.0 and added dependency on `Microsoft.SqlServer.Types` for improved functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->