### PR TITLE
MicrosoftSQL.ExecuteProcedure - Added handling of SqlGeography and SqlGeometry DB types

### DIFF
--- a/Frends.MicrosoftSQL.ExecuteProcedure/CHANGELOG.md
+++ b/Frends.MicrosoftSQL.ExecuteProcedure/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.0] - 2024-12-16
+- Added method to form JToken from the SqlDataReader so that SqlGeography and SqlGeometry typed objects can be handled.
+- Fixed how Scalar handles the data so that SqlGeography and SqlGeometry typed objects can be handled.
+- Added Microsoft.SqlServer.Types version 160.1000.6 as dependency.
+
 ## [2.1.0] - 2024-08-26
 ### Changed
 - Updated Newtonsoft.Json to the latest version 13.0.3.

--- a/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.Tests/ExecuteReaderUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.Tests/ExecuteReaderUnitTests.cs
@@ -378,7 +378,7 @@ DECLARE cur CURSOR
             Helper.ExecuteNonQuery("IF OBJECT_ID('InsertGeography') IS NOT NULL DROP PROCEDURE InsertGeography");
             Helper.ExecuteNonQuery("IF OBJECT_ID('InsertGeometry') IS NOT NULL DROP PROCEDURE InsertGeometry");
             Helper.ExecuteNonQuery("IF OBJECT_ID('SelectGeography') IS NOT NULL DROP PROCEDURE SelectGeography");
-            
+
             Helper.ExecuteNonQuery($"DROP TABLE {table}");
         }
     }

--- a/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.Tests/ExecuteReaderUnitTests.cs
+++ b/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.Tests/ExecuteReaderUnitTests.cs
@@ -344,10 +344,9 @@ DECLARE cur CURSOR
 
         command = $"CREATE PROCEDURE SelectGeography AS select * from {table}";
         Helper.ExecuteNonQuery(command);
-        
+
         try
         {
-            
             input.Execute = "InsertGeography";
 
             var result = await MicrosoftSQL.ExecuteProcedure(input, options, default);
@@ -376,8 +375,11 @@ DECLARE cur CURSOR
         }
         finally
         {
-            command = $"DROP TABLE {table}";
-            Helper.ExecuteNonQuery(command);
+            Helper.ExecuteNonQuery("IF OBJECT_ID('InsertGeography') IS NOT NULL DROP PROCEDURE InsertGeography");
+            Helper.ExecuteNonQuery("IF OBJECT_ID('InsertGeometry') IS NOT NULL DROP PROCEDURE InsertGeometry");
+            Helper.ExecuteNonQuery("IF OBJECT_ID('SelectGeography') IS NOT NULL DROP PROCEDURE SelectGeography");
+            
+            Helper.ExecuteNonQuery($"DROP TABLE {table}");
         }
     }
 }

--- a/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.csproj
+++ b/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure/Frends.MicrosoftSQL.ExecuteProcedure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.1.0</Version>
+	<Version>2.2.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -24,5 +24,6 @@
   <ItemGroup>
   	<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	<PackageReference Include="Microsoft.SqlServer.Types" Version="160.1000.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
#62 

## [2.2.0] - 2024-12-16
- Added method to form JToken from the SqlDataReader so that SqlGeography and SqlGeometry typed objects can be handled.
- Fixed how Scalar handles the data so that SqlGeography and SqlGeometry typed objects can be handled.
- Added Microsoft.SqlServer.Types version 160.1000.6 as dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method for creating `JToken` from `SqlDataReader`, enhancing support for `SqlGeography` and `SqlGeometry` types.
	- Added a new test for executing SQL procedures that handle geography data types.

- **Bug Fixes**
	- Improved handling of data in the `Scalar` method to support spatial types.

- **Chores**
	- Updated project version to 2.2.0 and added a dependency on `Microsoft.SqlServer.Types` version 160.1000.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->